### PR TITLE
Dockerises population-linkage

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,18 @@
+# Use Maven to run
+FROM maven:3.9.9-eclipse-temurin-21-jammy
+
+# Set working directory inside the container
+WORKDIR /app
+
+# Copy pom.xml, source code and entrypoint
+COPY pom.xml .
+COPY src ./src
+COPY docker/port_forwarding.sh .
+
+# Install dependencies
+RUN mvn clean install
+
+# Install socat for traffic forwarding
+RUN apt update && apt install -y socat
+
+RUN chmod +x ./*.sh ./src/main/scripts/**/*.sh

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,72 @@
+# Population_linkage with Docker
+The `population_linkage` library can be used and deployed in a portable containerised format. The following guide details how to build and run the image.
+
+## 1. Prerequisites
+The following tools must be installed on your system to follow this guide:
+- [Git](https://git-scm.com/)
+- [Docker](https://www.docker.com/), [Podman](https://podman.io/) or any other container management tool
+- A Neo4J container hosting the population data
+
+## 2. Installing and building
+### 2.1. Installing the repository
+You will need the `population_linkage` repository installed on your system to build the image. To install this, run the following command:
+
+```sh
+# In a terminal (Windows/macOS/Linux)
+git clone https://github.com/stacs-srg/population-linkage.git 
+```
+
+### 2.2. Building the images
+As this repository is large and offer a number of use-cases and entrypoints, the Docker setup consists of a base image and then implementations of this base image for different entrypoints.
+
+To build the base image, run the following command from the root of the repository:
+
+```sh
+# In a terminal (Windows/macOS/Linux)
+docker build . -f docker/Dockerfile -t population-linkage-base:latest
+```
+
+For this guide, we will be using the *runall* image (for the `src/main/scripts/endtoend/runall.sh` entrypoint). To build this, we then run the following command:
+
+```sh
+# In a terminal (Windows/macOS/Linux)
+docker build . -f docker/runall/Dockerfile -t population-linkage-runall:latest
+```
+
+## 3. Running
+### 3.1. Creating a Docker Network
+The `population_linkage` Docker setup is designed for use with a seperate Neo4J database container (e.g the [umea-neo4j-wrapper repository](https://github.com/jamesross03/umea-neo4j-wrapper)).
+
+To interact with a second container, you will need to setup a Docker network. To do this, run the following command:
+
+```sh
+# In a terminal (Windows/macOS/Linux)
+docker network create umea-neo4j-net
+```
+
+Where `umea-neo4j-net` is the name of the Docker network.
+
+To connect to this with another container, simply add the following flag when running your second container:
+
+```sh
+# In a terminal (Windows/macOS/Linux)
+--network umea-neo4j-net
+```
+
+### 3.2. Running the Docker image
+To run the image created above, use the following command:
+
+```sh
+# In a terminal (Windows/macOS/Linux)
+docker run --network umea-neo4j-net population-linkage-runall:latest
+```
+
+Note: By default the container attempts to connect with a Neo4J database hosted by a container named `umea-neo4j`. If this is not the case, [see 3.3](#33-setting-hostname) for details on overriding this. 
+
+### 3.3. Setting hostname
+The hostname of the Neo4J database container can be configured at runtime by using environment variables. To do this simply add the following flag to the run command (replacing `<HOSTNAME>` with the name of your container).
+
+```sh
+# In a terminal (Windows/macOS/Linux)
+--e NEO4J_HOST=<HOSTNAME>
+```

--- a/docker/port_forwarding.sh
+++ b/docker/port_forwarding.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+#
+# This script sets up traffic-forwarding to redirect traffic intended for a
+# localhost Neo4J server to the same ports on another host.
+#
+
+HOST=${NEO4J_HOST:-umea-neo4j}
+
+# Forward ports to umea-neo4j container
+socat TCP-LISTEN:7474,fork TCP:$HOST:7474 &
+socat TCP-LISTEN:7687,fork TCP:$HOST:7687 &

--- a/docker/runall/Dockerfile
+++ b/docker/runall/Dockerfile
@@ -1,0 +1,8 @@
+FROM population-linkage-base
+
+# Copy entrypoint
+WORKDIR /app
+COPY docker/runall/entrypoint.sh .
+RUN chmod +x ./entrypoint.sh
+
+ENTRYPOINT ["./entrypoint.sh"]

--- a/docker/runall/entrypoint.sh
+++ b/docker/runall/entrypoint.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+#
+# This script sets up port-forwarding for the container and calls the runall.sh
+# runner script.
+#
+
+# Start traffic forwarding
+./port_forwarding.sh
+
+# Run all
+./src/main/scripts/endtoend/runall.sh

--- a/src/main/scripts/endtoend/dolinkage_template.sh
+++ b/src/main/scripts/endtoend/dolinkage_template.sh
@@ -16,7 +16,6 @@
 # <http://www.gnu.org/licenses/>.
 #
 
-cd /Users/al/repos/github/population-linkage
 echo "in dir $PWD"
 
 if [ "$#" -eq  "0" ]
@@ -26,10 +25,6 @@ then
 fi
 
 EXEC_ARGS="umea ${1}"
-
-COPY=/Users/al/repos/github/population-linkage/src/main/scripts/neo4j/COPY_DB.sh
-
-COPYDIR=/Users/al/Desktop/NEOCOPY/
 
 export MAVEN_OPTS="-Xmx16G"
 

--- a/src/main/scripts/endtoend/runall.sh
+++ b/src/main/scripts/endtoend/runall.sh
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 #
 # Copyright 2022 Systems Research Group, University of St Andrews:
 # <https://github.com/stacs-srg>


### PR DESCRIPTION
## Overview
Adds Docker support for the `population-linkage` library, with a base image for the library and then different implementations of this image for running different tests/entrypoints. 

The container features a port-forwarding functionality, facilitating connections to a Neo4J container hosted in a separate container on the host machine, without any modification to the existing shell-scripts. Also adds `docker/README.md`, which contains usage instructions for the containerised setup.

Also removes hardcoded references to locations on previous developers hard-drives.

## Changelist
**Additions:**
- Adds Dockerfiles for a base image for the repository and an extension of this for running `src/main/scripts/endtoend/runall.sh` as an entrypoint.
- Adds a port-forwarding script for the Docker containers to facilitate connections with a Neo4J instance hosted in a separate container.

**Documentation:**
- Adds `docker/README.md`, with instructions on how to build and run the application in it's containerised setup.

**General improvements:**
- Adds missing shebang in `src/main/scripts/endtoend/runall.sh`  shell script.
- Removes redundant hardcoded filepaths in `src/main/scripts/endtoend/dolinkage_template.sh`.