### PR TITLE
Resurrects IJDPS experiments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ src/main/scripts/R/.Rhistory
 .run
 venv
 *.png
+results

--- a/docker/README.md
+++ b/docker/README.md
@@ -58,10 +58,13 @@ To run the image created above, use the following command:
 
 ```sh
 # In a terminal (Windows/macOS/Linux)
-docker run --network umea-neo4j-net population-linkage-runall:latest
+docker run --network umea-neo4j-net -v ./results:/app/results population-linkage-runall:latest
 ```
 
-Note: By default the container attempts to connect with a Neo4J database hosted by a container named `umea-neo4j`. If this is not the case, [see 3.3](#33-setting-hostname) for details on overriding this. 
+Note:
+- By default the container attempts to connect with a Neo4J database hosted by a container named `umea-neo4j`. If this is not the case, [see 3.3](#33-setting-hostname) for details on overriding this. 
+- `results/` directory must be created before running this command.
+- Not all containers will output results to `results/` directory.
 
 ### 3.3. Setting hostname
 The hostname of the Neo4J database container can be configured at runtime by using environment variables. To do this simply add the following flag to the run command (replacing `<HOSTNAME>` with the name of your container).
@@ -70,3 +73,8 @@ The hostname of the Neo4J database container can be configured at runtime by usi
 # In a terminal (Windows/macOS/Linux)
 --e NEO4J_HOST=<HOSTNAME>
 ```
+
+## 4. Supported setups/entrypoints
+The above guide builds and runs the `runall` image but this is not the only available Docker setup/entrypoint:
+- **`runall`** - runs threshold analysers, linkage scripts, and then resolvers.
+- **`ijdps`** - runs threshold experiments for IJDPS paper.

--- a/docker/ijdps/Dockerfile
+++ b/docker/ijdps/Dockerfile
@@ -1,0 +1,8 @@
+FROM population-linkage-base
+
+# Copy entrypoint
+WORKDIR /app
+COPY docker/ijdps/entrypoint.sh .
+RUN chmod +x ./entrypoint.sh
+
+ENTRYPOINT ["./entrypoint.sh"]

--- a/docker/ijdps/entrypoint.sh
+++ b/docker/ijdps/entrypoint.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+#
+# This script sets up port-forwarding for the container and calls the runall.sh
+# runner script.
+#
+
+# Start traffic forwarding
+./port_forwarding.sh
+
+# Run all
+./src/main/scripts/experiments/umea_IJDPS_paper/experiments/run_all_experiments.sh

--- a/src/main/scripts/experiments/umea_IJDPS_paper/experiments/run_all_experiments.sh
+++ b/src/main/scripts/experiments/umea_IJDPS_paper/experiments/run_all_experiments.sh
@@ -19,7 +19,11 @@
 MAX_HEAP_GB="100"
 RECORDS_TO_BE_CHECKED="25000"
 NUMBER_OF_RUNS="1"
-OUTPUT_DIR="full-experiment"      # Blank for project root directory.
+# Sets results directory to be unique
+OUTPUT_DIR="results/IJDPS_paper/$(date '+%Y%m%d_%H%M%S')"
+
+# Create results directory if it doesn't already exist
+mkdir -p $OUTPUT_DIR
 
 "$(dirname $0)"/umea_birth_father_identity.sh ${MAX_HEAP_GB} ${RECORDS_TO_BE_CHECKED} ${NUMBER_OF_RUNS} ${OUTPUT_DIR}
 "$(dirname $0)"/umea_birth_mother_identity.sh ${MAX_HEAP_GB} ${RECORDS_TO_BE_CHECKED} ${NUMBER_OF_RUNS} ${OUTPUT_DIR}


### PR DESCRIPTION
## Overview
Adds a Docker setup and entrypoint for the IJDPS paper experiments. Also updates the runner shell script for these experiments to create the results directory and parent directories if they do not already exist. Now outputs to `results/IJDPS_paper/<timestamp>/` to aid repeatability of experiments (by avoiding overwriting) and improve results organisation. Notes on running this setup and mounting results volumes added to `README.md`.

Closes #17 

## Changelist
**Additions:**
- Adds docker setup and entrypoint for running the IJDPS paper experiments (with `/src/main/scripts/experiments/umea_IJDPS_paper/experiments/run_all_experiments.sh`).

**Changes:**
- IJDPS experiments now output to `results/IJDPS_paper/<timestamp>/` instead of `full-experiments`.

**Fixes:**
- IJDPS `run_all_experiments.sh` now creates results directory before attempting to run experiments, thus avoiding throwing `FileNotFoundException`.

**Documentation:**
- Adds list of buildable containers and notes on mounting `results` directories to `docker/README.md`.

**Repository:**
- Added `results/` directory to `.gitignore`.